### PR TITLE
SimpleAffableBean-12 Remove uses of ex.printStackTrace 

### DIFF
--- a/src/java/controller/AdminServlet.java
+++ b/src/java/controller/AdminServlet.java
@@ -49,6 +49,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -66,6 +68,8 @@ import javax.servlet.http.HttpSession;
                     rolesAllowed = {"simpleAffableBeanAdmin"})
 )
 public class AdminServlet extends HttpServlet {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public void init(ServletConfig config) throws ServletException {
@@ -151,7 +155,7 @@ public class AdminServlet extends HttpServlet {
         try {
             request.getRequestDispatcher(userPath).forward(request, response);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            logger.error("Failed to forward to JSP {}", userPath, ex);
         }
     }
 

--- a/src/java/controller/ErrorServlet.java
+++ b/src/java/controller/ErrorServlet.java
@@ -84,7 +84,7 @@ public class ErrorServlet extends SimpleAffableBeanServlet {
         try {
             request.getRequestDispatcher(url).forward(request, response);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            logger.error("Failed to forward to URL {}", url, ex);
         }
     }
 

--- a/src/java/controller/SimpleAffableBeanServlet.java
+++ b/src/java/controller/SimpleAffableBeanServlet.java
@@ -39,6 +39,8 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -47,6 +49,7 @@ import javax.servlet.http.HttpServletResponse;
             loadOnStartup = 1)
 public class SimpleAffableBeanServlet extends HttpServlet {
 
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public void init(ServletConfig servletConfig) throws ServletException {
@@ -96,7 +99,7 @@ public class SimpleAffableBeanServlet extends HttpServlet {
         try {
             request.getRequestDispatcher(url).forward(request, response);
         } catch (Exception ex) {
-            ex.printStackTrace();
+            logger.error("Failed to forward to url {}", url, ex);
         }
     }
 

--- a/src/java/filter/SessionTimeoutFilter.java
+++ b/src/java/filter/SessionTimeoutFilter.java
@@ -42,6 +42,8 @@ import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -49,6 +51,7 @@ import javax.servlet.http.HttpSession;
  */
 @WebFilter(servletNames = {"Cart", "Category", "Checkout", "AdminServlet", "Confirmation", "Language"})
 public class SessionTimeoutFilter implements Filter {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
@@ -59,14 +62,15 @@ public class SessionTimeoutFilter implements Filter {
 
         HttpSession session = req.getSession(false);
 
-        // if session doesn't exist, forward user to welcome page
-        if (session != null && !"true".equals(req.getParameter("forceFilter"))) {
+        if (session != null || !"true".equals(req.getParameter("forceFilter"))) {
             chain.doFilter(request, response);
         } else {
+            final String location = req.getContextPath() + "/home";
             try {
-                res.sendRedirect(req.getContextPath() + "/home");
+                logger.info("Session timed out, redirecting to {}", location);
+                res.sendRedirect(location);
             } catch (Exception ex) {
-                ex.printStackTrace();
+                logger.error("Failed to redirect to {}", location, ex);
             }
         }
     }

--- a/web/WEB-INF/web.xml
+++ b/web/WEB-INF/web.xml
@@ -62,9 +62,8 @@
     </context-param>
 
     <session-config>
-        <session-timeout>
-            15
-        </session-timeout>
+        <session-timeout>15</session-timeout>
+        <tracking-mode>COOKIE</tracking-mode>
     </session-config>
 
     <!--This is only needed for testing the datasource (TestDataSource.jsp)-->


### PR DESCRIPTION
Use slf4j loggers instead.
Note that we do not need these to be final if they are 
member variables in singleton Filter or Servlet 
classes already.